### PR TITLE
onthisday page now shows pictures of past three years when the image is clicked

### DIFF
--- a/soloespresso/onthisday.html
+++ b/soloespresso/onthisday.html
@@ -27,10 +27,12 @@
 	
 			<hr/>
 
-            <img id="image" width=550px onclick="toggleImage();"/>
+            <img id="image" width=550px onclick="imageSequence();"/>
             <p> <em><span id="date">date</span></em> Click on the photo to see entries from this day last year and the year before!</p>
 
             <script>  
+
+            /* This function formats a given date as dd-mm-yyyy and subtracts the number 'years' from the year. */
             function formatDate(date, years) {
                 var d = new Date(date),
                     month = '' + (d.getMonth() + 1),
@@ -45,19 +47,30 @@
                 return [year, month, day].join('-');
             }
 
-            function toggleImage() {
-                var img1 = "https://raw.githubusercontent.com/merlijnkersten/merlijnkersten.github.io/master/assets/soloespresso" + formatDate(today, 1) + ".jpg";
-                var img2 = "https://raw.githubusercontent.com/merlijnkersten/merlijnkersten.github.io/master/assets/soloespresso" + formatDate(today, 2) + ".jpg";
-            
-                var imgElement = document.getElementById('image');
+            var today = new Date()
 
-                imgElement.src = (imgElement.src === img1)? img2 : img1;
+            /*
+            Used: https://stackoverflow.com/questions/39919038/javascript-changing-between-three-images-on-a-button-click, answer by https://stackoverflow.com/users/949476/dfsq
+            */
+            
+
+            /* First image uploaded on 22 April 2019, keep adding previous years as project continues */
+            var images = [
+                "https://raw.githubusercontent.com/merlijnkersten/merlijnkersten.github.io/master/assets/soloespresso" + formatDate(today, 1) + ".jpg",
+                "https://raw.githubusercontent.com/merlijnkersten/merlijnkersten.github.io/master/assets/soloespresso" + formatDate(today, 2) + ".jpg",
+                "https://raw.githubusercontent.com/merlijnkersten/merlijnkersten.github.io/master/assets/soloespresso" + formatDate(today, 3) + ".jpg"
+            ]
+
+            var num = 1
+
+            /* This function cycles through the 'images' list by taking the modulo of the 'num' iterator divided by the length of the 'images' list.*/
+            function imageSequence() { 
+                document.getElementById('image').src = images[num++ % images.length];
             }
 
-            var today = new Date()
-            
             document.querySelector("#image").src = "https://raw.githubusercontent.com/merlijnkersten/merlijnkersten.github.io/master/assets/soloespresso" + formatDate(today, 1) + ".jpg";
             
+            /* Print the day's date below the picture in dd mmmm format. */
             var date = today.getDate() +' ' + today.toLocaleString('default', { month: 'long' })
             
             document.querySelector("#date").innerText = date


### PR DESCRIPTION
It should be straightforward to add further years (every April) to the list. This can be done either by updating the list annually, or by writing a short function to include a picture for every year since April 2019.